### PR TITLE
Update SwerveSubsystem.java

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -22,6 +22,7 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -342,7 +343,7 @@ public class SwerveSubsystem extends SubsystemBase
                                                         yInput,
                                                         headingX,
                                                         headingY,
-                                                        -getHeading().getRadians(),
+                                                        (RobotBase.isReal()?-1 : 1) * -getHeading().getRadians(),
                                                         maximumSpeed);
   }
 


### PR DESCRIPTION
if it is in a simulation it no longer inverts gyro so the sim robot doesn't have a seizure.